### PR TITLE
Change variable name for --prefix to ${SYSROOT}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,4 @@ config.log
 config.status
 configure.scan
 config.h
-libs/
+sysroot/

--- a/build.sh
+++ b/build.sh
@@ -11,41 +11,41 @@ GREEN=`tput setaf 2`
 RESET=`tput sgr0`
 
 pushd deps/bc-crypto-base
-./configure --prefix ${LIBS}
+./configure --prefix ${SYSROOT}
 make check
 make install
 popd
 
 pushd deps/bc-shamir
-./configure --prefix ${LIBS}
+./configure --prefix ${SYSROOT}
 make check
 make install
 popd
 
 pushd deps/bc-slip39
-./configure --prefix ${LIBS}
+./configure --prefix ${SYSROOT}
 make check
 make install
 popd
 
 pushd deps/bc-bip39
-./configure --prefix ${LIBS}
+./configure --prefix ${SYSROOT}
 make check
 make install
 popd
 
 pushd deps/bc-bech32
-./configure --prefix ${LIBS}
+./configure --prefix ${SYSROOT}
 make check
 make install
 popd
 
 pushd deps/argp-standalone/argp-standalone
 patch -N <../patch-argp-fmtstream.h
-./configure --prefix ${LIBS}
+./configure --prefix ${SYSROOT}
 make install
-cp libargp.a ${LIBS}/lib/
-cp argp.h ${LIBS}/include/
+cp libargp.a ${SYSROOT}/lib/
+cp argp.h ${SYSROOT}/include/
 popd
 
 ./configure

--- a/set_build_paths.sh
+++ b/set_build_paths.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-LIBS=${PWD}/libs
-LIB=${LIBS}/lib
-INCLUDE=${LIBS}/include
+SYSROOT=${PWD}/sysroot
+LIB=${SYSROOT}/lib
+INCLUDE=${SYSROOT}/include
 
 export CFLAGS="${CFLAGS} -I${INCLUDE}"
 export CXXFLAGS="${CXXFLAGS} -I${INCLUDE}"


### PR DESCRIPTION
It was a bit confusing when I was first reviewing the build scripts to see a variable ${LIBS} used in the way it is.  ${LIBS} usually contains the libraries to link with.  The common name for a '--prefix' path is the system root, or SYSROOT.  Using this terminology might save some others who look at this code a few moments confusion.