### PR TITLE
github actions: build/test on Linux and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build-MacOS:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: brew install autoconf automake libtool shunit2
+    - run: ./build.sh
+    - run: sudo make install
+    - run: make distclean
+
+  build-Linux:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
+    - run: sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" || exit 1
+    - run: sudo apt-get update || exit 1
+    - run: sudo apt-get install -y clang-10 libc++-10-dev libc++abi-10-dev shunit2 make || exit 1
+    - run: export CC="clang-10" && export CXX="clang++-10" && ./build.sh
+    - run: sudo make install
+    - run: make distclean
+


### PR DESCRIPTION
## Abstract

Should work, have tested in my repo: https://github.com/gorazdko/bc-seedtool-cli/actions

Admin can then add required checks/rules (Settings->branches), for example only for MacOS build.
In addition, badges can be added to the `README` to see the last status of building the master branch 