### PR TITLE
linter: exclude style severity

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -123,4 +123,4 @@ distclean: clean
 
 .PHONY: lint
 lint:
-	cppcheck --enable=all --error-exitcode=1 --inline-suppr --suppress=missingInclude --suppress=ConfigurationNotChecked .
+	cppcheck --enable=warning,performance,information --error-exitcode=1 --inline-suppr --suppress=missingInclude --suppress=ConfigurationNotChecked .


### PR DESCRIPTION
## Abstract

cppcheck throws an error on new PRs (e.g. #53). I'm not sure why as these PRs don't introduce any (relevant) code, while master branch is considered OK by cppcheck.

Given that seedtool manual says warning severity suffices I'm suggesting to remove the style severity in this PR

> make lint uses Cppcheck to perform static analysis on the code. All PRs should pass with no warnings.

See https://github.com/BlockchainCommons/bc-seedtool-cli/pull/54#issuecomment-811108198 for the 'warnings' issued by cppcheck

@wolfmcnally please advise